### PR TITLE
refactor lib structure

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -1,11 +1,8 @@
 import { resolve, join } from 'path'
 import { readdirSync } from 'fs'
+import HTTP from './core/HTTP'
 import type { Module } from '@nuxt/types'
 import type { AxiosInstance } from 'axios'
-
-import HTTP from './core/HTTP'
-
-const libRoot = __dirname
 
 declare module '@nuxt/types' {
     interface Context {
@@ -30,27 +27,35 @@ const nuxtDTOModule: Module = function module (moduleOptions: any) {
     ...moduleOptions
   }
 
-  const coreRoot = resolve(libRoot, 'core')
+  const directoriesToSyncInBuildDir = [
+    'core',
+    'plugins'
+  ]
 
-  for (const file of readdirSync(coreRoot)) {
-    this.addTemplate({
-      src: resolve(coreRoot, file),
-      fileName: join('nuxt-dto', file)
-    })
+  const namespace = 'nuxt-dto'
+
+  for (const dir of directoriesToSyncInBuildDir) {
+    const path = resolve(__dirname, dir)
+    for (const file of readdirSync(path)) {
+      this.addTemplate({
+        src: resolve(path, file),
+        fileName: join(namespace, dir, file)
+      })
+    }
   }
 
   const plugins = [
-    'plugin.js'
+    'plugins/http.js'
   ]
 
   if (options.debug) {
-    plugins.unshift('logger.js')
+    plugins.unshift('plugins/logger.js')
   }
 
   for (const path of plugins) {
     this.addPlugin({
       src: resolve(__dirname, path),
-      fileName: 'nuxt-dto/' + path,
+      fileName: join(namespace, path),
       options
     })
   }
@@ -59,5 +64,6 @@ const nuxtDTOModule: Module = function module (moduleOptions: any) {
 export { PropsMap, PropMap, Prop, Model, default as mapModel } from './core/Mapper'
 export { default as HTTP } from './core/HTTP'
 export { default as ApiResponse } from './core/ApiResponse'
-export { default as logger } from './logger'
+export { default as logger } from './plugins/logger'
+(nuxtDTOModule as any).meta = require('../package.json')
 export default nuxtDTOModule

--- a/lib/plugins/http.ts
+++ b/lib/plugins/http.ts
@@ -4,8 +4,7 @@ import Handler from '<%= options.handler %>' /*
 <% } %> */
 
 import type { Plugin } from '@nuxt/types'
-// @ts-ignore
-import HTTP from './HTTP'
+import HTTP from '../core/HTTP'
 
 const myPlugin: Plugin = (context, inject) => {
   let ResponseHandler: any = null

--- a/lib/plugins/logger.ts
+++ b/lib/plugins/logger.ts
@@ -1,7 +1,6 @@
-import { AxiosError, AxiosResponse } from 'axios'
+import type { AxiosError, AxiosResponse } from 'axios'
+import type HTTP from '../core/HTTP'
 import consola from 'consola'
-// @ts-ignore
-import type HTTP from './HTTP'
 
 const logger = consola.withScope('nuxt-dto')
 


### PR DESCRIPTION
@farnabaz I think by outputting the exact structure in `nuxt` build directory, we can keep everything in sync and by the way we don't have to be concerned of importing anything relative to the final build. 

For example, instead of doing this:
```ts
//@ts-ignore
import HTTP from './HTTP'
```

Now we can do relative to our lib directory:

```js
import HTTP from '../core/HTTP'
```

Therefore, having this structure:

```
.
|-- lib
|   |-- core
|   |-- plugins
|   |-- module.ts
```
Resolve the same in the `nuxt` build directory:

```
.
| --.nuxt
|   |-- nuxt-dto
|       |-- core
|       |-- plugins
```